### PR TITLE
Initial pass at text wrapping support via foreignObject

### DIFF
--- a/dist/elements/text.js
+++ b/dist/elements/text.js
@@ -39,11 +39,19 @@ var Text = function (_DraggableBase) {
   }
 
   _createClass(Text, [{
+    key: 'height',
+    value: function height() {
+      console.log(this);
+      return 10;
+    }
+  }, {
     key: 'render',
     value: function render() {
       var _props = this.props;
       var x = _props.x;
       var y = _props.y;
+      var width = _props.width;
+      var wrapping = _props.wrapping;
       var fill = _props.fill;
       var fontSize = _props.fontSize;
       var fontFamily = _props.fontFamily;
@@ -56,22 +64,50 @@ var Text = function (_DraggableBase) {
 
       var lineHeight = this.props.lineHeight || fontSize;
 
+      var svgPropsToStyle = {
+        color: fill || null,
+        fontSize: fontSize,
+        fontFamily: fontFamily,
+        fontWeight: fontWeight,
+        margin: 0
+      };
+
       if (util.isArray(text)) {
         text = text.map(function (string, index) {
           if (true === smartQuotes) {
             string = string.addSmartQuotes();
           }
 
-          return React.createElement(
-            'tspan',
-            { key: index, x: x, y: lineHeight * index + y, alignmentBaseline: 'before-edge' },
-            string
-          );
+          if (wrapping && width) {
+            return React.createElement(
+              'p',
+              { key: index, xmlns: 'http://www.w3.org/1999/xhtml', style: svgPropsToStyle },
+              string
+            );
+          } else {
+            return React.createElement(
+              'tspan',
+              { key: index, x: x, y: lineHeight * index + y, alignmentBaseline: 'before-edge' },
+              string
+            );
+          }
         });
       } else {
         if (true === smartQuotes) {
           text = text.addSmartQuotes();
         }
+      }
+
+      if (wrapping && width) {
+        return React.createElement(
+          'foreignObject',
+          _extends({ x: x,
+            y: y,
+            width: width,
+            ref: 'text'
+          }, this.draggableProps),
+          text
+        );
       }
 
       return React.createElement(

--- a/src/elements/text.js
+++ b/src/elements/text.js
@@ -19,9 +19,15 @@ String.prototype.addSmartQuotes = function() {
 
 class Text extends DraggableBase {
 
+  height() {
+    console.log(this);
+    return 10;
+  }
+
   render() {
     const {
       x, y,
+      width, wrapping,
       fill,
       fontSize, fontFamily, fontWeight,
       textAnchor, smartQuotes
@@ -31,18 +37,38 @@ class Text extends DraggableBase {
 
     let lineHeight = this.props.lineHeight || fontSize;
 
+    const svgPropsToStyle = {
+      color: fill || null,
+      fontSize: fontSize,
+      fontFamily: fontFamily,
+      fontWeight: fontWeight,
+      margin: 0
+    };
+
     if(util.isArray(text)) {
       text = text.map((string, index) => {
         if(true === smartQuotes) {
           string = string.addSmartQuotes();
         }
 
-        return (<tspan key={index} x={x} y={(lineHeight * index) + y} alignmentBaseline="before-edge">{string}</tspan>);
+        if(wrapping && width) {
+          return (<p key={index} xmlns="http://www.w3.org/1999/xhtml" style={svgPropsToStyle}>{string}</p>);
+        } else {
+          return (<tspan key={index} x={x} y={(lineHeight * index) + y} alignmentBaseline="before-edge">{string}</tspan>);
+        }
       });
     } else {
       if(true === smartQuotes) {
         text = text.addSmartQuotes();
       }
+    }
+
+    if(wrapping && width) {
+      return (<foreignObject x={x}
+                y={y}
+                width={width}
+                ref="text"
+                {...this.draggableProps}>{text}</foreignObject>)
     }
 
     return (


### PR DESCRIPTION
This PR adds support for a `wrapping` and `width` property on `<Text />` elements such that they can automatically wrap. It relies on the SVG `<foreignObject>` tag which contains `<p>` tags which will automatically wrap (see: http://stackoverflow.com/a/4991339).

Unfortunately this solution doesn't expose a way of accessing the height of the element, which causes issues for [CardKit](https://github.com/times/cardkit), which relies on the height of the element to be able to compute the `y` position of attached elements.

More work to be done to support this.